### PR TITLE
WIP: refactor: return map instead of plain response object in send-methods

### DIFF
--- a/clearinghouse/src/main/java/de/fraunhofer/ids/messaging/clearinghouse/IDSClearingHouseService.java
+++ b/clearinghouse/src/main/java/de/fraunhofer/ids/messaging/clearinghouse/IDSClearingHouseService.java
@@ -1,5 +1,7 @@
 package de.fraunhofer.ids.messaging.clearinghouse;
 
+import java.util.Map;
+
 import de.fraunhofer.iais.eis.Message;
 import de.fraunhofer.iais.eis.QueryLanguage;
 import de.fraunhofer.iais.eis.QueryScope;
@@ -15,7 +17,7 @@ public interface IDSClearingHouseService {
      * @return Response from ClearingHouse
      * @throws ClearingHouseClientException when some error occurs while sending the message to the ClearingHouse
      */
-    Response sendLogToClearingHouse(Message messageToLog) throws ClearingHouseClientException;
+    Map<String, String> sendLogToClearingHouse(Message messageToLog) throws ClearingHouseClientException;
 
     /**
      * Send a LogMessage with given pid to ClearingHouse.
@@ -25,7 +27,7 @@ public interface IDSClearingHouseService {
      * @return Response from ClearingHouse
      * @throws ClearingHouseClientException when some error occurs while sending the message to the ClearingHouse
      */
-    Response sendLogToClearingHouse(Message messageToLog, String pid) throws ClearingHouseClientException;
+    Map<String, String> sendLogToClearingHouse( Message messageToLog, String pid) throws ClearingHouseClientException;
 
     /**
      * Query the Clearing House (Currently not working correctly @ ClearingHouse, HTTP 500).
@@ -39,7 +41,7 @@ public interface IDSClearingHouseService {
      * @return Response from ClearingHouse
      * @throws ClearingHouseClientException when some error occurs while sending the message to the ClearingHouse
      */
-    Response queryClearingHouse(String pid, String messageid, QueryLanguage queryLanguage, QueryScope queryScope,
+    Map<String, String> queryClearingHouse(String pid, String messageid, QueryLanguage queryLanguage, QueryScope queryScope,
                                 QueryTarget queryTarget, String query) throws ClearingHouseClientException;
 
 }

--- a/messaging/src/main/java/de/fraunhofer/ids/messaging/protocol/http/HttpService.java
+++ b/messaging/src/main/java/de/fraunhofer/ids/messaging/protocol/http/HttpService.java
@@ -35,7 +35,8 @@ public interface HttpService {
      * @return true if the message was successfully sent, else false
      * @throws IOException if the request could not be executed due to cancellation, a connectivity problem or timeout.
      */
-    Response send(String message, URI target) throws IOException;
+    Map<String, String> send(String message, URI target)
+            throws IOException, MultipartParseException;
 
     /**
      * Sends plaintext message as http(s) request to the defined target.
@@ -44,7 +45,8 @@ public interface HttpService {
      * @return the HttpResponse that comes back for the sent Message
      * @throws IOException if the request could not be executed due to cancellation, a connectivity problem or timeout.
      */
-    Response send(Request request) throws IOException;
+    Map<String, String> send(Request request)
+            throws IOException, MultipartParseException;
 
     /**
      * Sends a given requestBody as http(s) request to the defined in address.
@@ -54,7 +56,8 @@ public interface HttpService {
      * @return the HttpResponse that comes back for the sent Message
      * @throws IOException if the request could not be executed due to cancellation, a connectivity problem or timeout.
      */
-    Response send(RequestBody requestBody, URI target) throws IOException;
+    Map<String, String> send(RequestBody requestBody, URI target)
+            throws IOException, MultipartParseException;
 
     /**
      * Sends a given requestBody as http(s) request to the defined in address,
@@ -66,7 +69,8 @@ public interface HttpService {
      * @return the HttpResponse that comes back for the sent Message
      * @throws IOException if the request could not be executed due to cancellation, a connectivity problem or timeout.
      */
-    Response sendWithHeaders(RequestBody requestBody, URI target, Map<String, String> headers) throws IOException;
+    Map<String, String> sendWithHeaders(RequestBody requestBody, URI target, Map<String, String> headers)
+            throws IOException, MultipartParseException;
 
     /**
      * Sends a http GET request to the target.
@@ -75,7 +79,8 @@ public interface HttpService {
      * @return the HttpResponse from the get request
      * @throws IOException if the request could not be executed due to cancellation, a connectivity problem or timeout.
      */
-    Response get(URI target) throws IOException;
+    Map<String, String> get(URI target)
+            throws IOException, MultipartParseException;
 
     /**
      * Sends a http GET request to the target,
@@ -86,7 +91,8 @@ public interface HttpService {
      * @return the HttpResponse from the get request
      * @throws IOException if the request could not be executed due to cancellation, a connectivity problem or timeout.
      */
-    Response getWithHeaders(URI target, Map<String, String> headers) throws IOException;
+    Map<String, String> getWithHeaders(URI target, Map<String, String> headers)
+            throws IOException, MultipartParseException;
 
     /**
      * @param request to be sent

--- a/messaging/src/test/java/de/fraunhofer/ids/messaging/protocol/http/IdsHttpServiceTest.java
+++ b/messaging/src/test/java/de/fraunhofer/ids/messaging/protocol/http/IdsHttpServiceTest.java
@@ -81,6 +81,6 @@ class IdsHttpServiceTest {
         //send a request using idsHttpService
         var response = idsHttpService.send("This is a Message.", mockWebServer.url("/").uri());
         //check if response body and MockWebServer response are equal
-        assertEquals("This is a response.", response.body().string());
+        assertEquals("This is a response.", response.get("payload"));
     }
 }


### PR DESCRIPTION
- all send-methods in IdsHttpService now return Map<String, String> (response.get("payload"), response.get("header") instead of plain response-object)
- clearinghouseService now uses sendAndCheckDat() instead of just send()