### PR TITLE
Forwarding of token claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## Version [4.2.0.0] UNRELEASED
+## Version [2.0.0] UNRELEASED
+With this version we switch to the verions-format of semantic versioning. In principle, only the first version-number position is omitted compared to the previous versions.
+
 
 ### Major Change: MessageContainer
 - Services now return MessageContainer, instead of xyzMAP tied to a specific expected response
@@ -28,6 +30,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Patch change: Added Maven plugin to generate Apache 2.0 license-header in files
+- Minor change: New feature, Token-Claims can now be accessed
 
 ### Changes
 - Patch Change: Improved logging structure and messages for TEST_DEPLOYMENT vs PRODUCTIVE_DEPLOYMENT

--- a/core/src/main/java/de/fraunhofer/ids/messaging/core/daps/DapsValidator.java
+++ b/core/src/main/java/de/fraunhofer/ids/messaging/core/daps/DapsValidator.java
@@ -81,6 +81,11 @@ public class DapsValidator {
         throw new ClaimsException("No given signing Key could validate JWT!");
     }
 
+    /**
+     * @param token incoming DAT token
+     * @return claims extracted from the DAT
+     * @throws ClaimsException if token cannot be parsed using a DAPS public key
+     */
     public Jws<Claims> getClaims(final DynamicAttributeToken token) throws ClaimsException {
         Jws<Claims> claims;
         final var keys = keyProvider.providePublicKeys();
@@ -93,6 +98,13 @@ public class DapsValidator {
         }
     }
 
+    /**
+     * Check the claims of the DAT
+     *
+     * @param claims JWS claims of DAT Token
+     * @param extraAttributes extra attributes to be checked
+     * @return true, if claims are valid
+     */
     public boolean checkClaims(final Jws<Claims> claims, final Map<String, Object> extraAttributes){
         if (extraAttributes != null && extraAttributes.containsKey("securityProfile")) {
             try {

--- a/core/src/main/java/de/fraunhofer/ids/messaging/core/daps/DapsValidator.java
+++ b/core/src/main/java/de/fraunhofer/ids/messaging/core/daps/DapsValidator.java
@@ -99,13 +99,13 @@ public class DapsValidator {
     }
 
     /**
-     * Check the claims of the DAT
+     * Check the claims of the DAT.
      *
      * @param claims JWS claims of DAT Token
      * @param extraAttributes extra attributes to be checked
      * @return true, if claims are valid
      */
-    public boolean checkClaims(final Jws<Claims> claims, final Map<String, Object> extraAttributes){
+    public boolean checkClaims(final Jws<Claims> claims, final Map<String, Object> extraAttributes) {
         if (extraAttributes != null && extraAttributes.containsKey("securityProfile")) {
             try {
                 verifySecurityProfile(claims.getBody().get("securityProfile", String.class),

--- a/messaging/src/main/java/de/fraunhofer/ids/messaging/dispatcher/MessageDispatcher.java
+++ b/messaging/src/main/java/de/fraunhofer/ids/messaging/dispatcher/MessageDispatcher.java
@@ -27,7 +27,6 @@ import de.fraunhofer.ids.messaging.core.daps.ClaimsException;
 import de.fraunhofer.ids.messaging.core.daps.DapsValidator;
 import de.fraunhofer.ids.messaging.dispatcher.filter.PreDispatchingFilter;
 import de.fraunhofer.ids.messaging.dispatcher.filter.PreDispatchingFilterException;
-import de.fraunhofer.ids.messaging.dispatcher.filter.PreDispatchingFilterResult;
 import de.fraunhofer.ids.messaging.handler.message.MessageAndClaimsHandler;
 import de.fraunhofer.ids.messaging.handler.message.MessageHandler;
 import de.fraunhofer.ids.messaging.handler.message.MessageHandlerException;
@@ -104,7 +103,7 @@ public class MessageDispatcher {
             try {
                 final var claims = dapsValidator.getClaims(header.getSecurityToken());
                 optionalClaimsJws = Optional.ofNullable(claims);
-                if(!dapsValidator.checkClaims(claims, null)){
+                if (!dapsValidator.checkClaims(claims, null)) {
                     return ErrorResponse.withDefaultHeader(
                             RejectionReason.NOT_AUTHORIZED, "DAT could not be verified!", connectorId,
                             modelVersion, header.getId());
@@ -157,10 +156,10 @@ public class MessageDispatcher {
             //if an handler exists, let the handle handle the message and return its response
             try {
                 final var handler = (MessageHandler<R>) resolvedHandler.get();
-                if(handler instanceof MessageAndClaimsHandler){
+                if (handler instanceof MessageAndClaimsHandler) {
                     //for MessageAndClaims handlers, also pass parsed DAT claims
                     return ((MessageAndClaimsHandler) handler).handleMessage(header, new MessagePayloadInputstream(payload, objectMapper), optionalClaimsJws);
-                }else{
+                } else {
                     return handler.handleMessage(header, new MessagePayloadInputstream(payload, objectMapper));
                 }
             } catch (MessageHandlerException e) {

--- a/messaging/src/main/java/de/fraunhofer/ids/messaging/dispatcher/MessageDispatcher.java
+++ b/messaging/src/main/java/de/fraunhofer/ids/messaging/dispatcher/MessageDispatcher.java
@@ -98,7 +98,7 @@ public class MessageDispatcher {
         final var connectorId = configContainer.getConnector().getId();
         final var modelVersion = configContainer.getConnector().getOutboundModelVersion();
 
-        //check dat and cache claims
+        //check dat and save token claims
         Optional<Jws<Claims>> optionalClaimsJws = Optional.empty();
         if (configContainer.getConfigurationModel().getConnectorDeployMode() == ConnectorDeployMode.PRODUCTIVE_DEPLOYMENT) {
             try {
@@ -154,11 +154,11 @@ public class MessageDispatcher {
 
         // Checks if revolvedHandler is not null
         if (resolvedHandler.isPresent()) {
-
             //if an handler exists, let the handle handle the message and return its response
             try {
                 final var handler = (MessageHandler<R>) resolvedHandler.get();
                 if(handler instanceof MessageAndClaimsHandler){
+                    //for MessageAndClaims handlers, also pass parsed DAT claims
                     return ((MessageAndClaimsHandler) handler).handleMessage(header, new MessagePayloadInputstream(payload, objectMapper), optionalClaimsJws);
                 }else{
                     return handler.handleMessage(header, new MessagePayloadInputstream(payload, objectMapper));

--- a/messaging/src/main/java/de/fraunhofer/ids/messaging/handler/message/MessageAndClaimsHandler.java
+++ b/messaging/src/main/java/de/fraunhofer/ids/messaging/handler/message/MessageAndClaimsHandler.java
@@ -21,11 +21,11 @@ import io.jsonwebtoken.Jws;
 import java.util.Optional;
 
 /**
- * MessageHandler, also passing DAT Claims for additional checks
+ * MessageHandler, also passing DAT Claims for additional checks.
  *
  * @param <T> Type of Message accepted by handler
  */
-public interface MessageAndClaimsHandler<T extends Message> extends MessageHandler<T>{
+public interface MessageAndClaimsHandler<T extends Message> extends MessageHandler<T> {
 
     /**
      * {@inheritDoc}

--- a/messaging/src/main/java/de/fraunhofer/ids/messaging/handler/message/MessageAndClaimsHandler.java
+++ b/messaging/src/main/java/de/fraunhofer/ids/messaging/handler/message/MessageAndClaimsHandler.java
@@ -7,13 +7,28 @@ import io.jsonwebtoken.Jws;
 
 import java.util.Optional;
 
+/**
+ * MessageHandler, also passing DAT Claims for additional checks
+ *
+ * @param <T> Type of Message accepted by handler
+ */
 public interface MessageAndClaimsHandler<T extends Message> extends MessageHandler<T>{
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     default MessageResponse handleMessage(T queryHeader, MessagePayload payload) throws MessageHandlerException {
         return handleMessage(queryHeader, payload, Optional.empty());
     }
 
+    /**
+     * @param queryHeader IDS Message Header
+     * @param payload Payload of Message
+     * @param optionalClaimsJws optional containing claims of the messages DAT
+     * @return Response (which will be sent back to the requesting connector)
+     * @throws MessageHandlerException when some error happens while handling the message
+     */
     MessageResponse handleMessage(T queryHeader, MessagePayload payload, Optional<Jws<Claims>> optionalClaimsJws) throws MessageHandlerException;
 
 

--- a/messaging/src/main/java/de/fraunhofer/ids/messaging/handler/message/MessageAndClaimsHandler.java
+++ b/messaging/src/main/java/de/fraunhofer/ids/messaging/handler/message/MessageAndClaimsHandler.java
@@ -1,0 +1,20 @@
+package de.fraunhofer.ids.messaging.handler.message;
+
+import de.fraunhofer.iais.eis.Message;
+import de.fraunhofer.ids.messaging.response.MessageResponse;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+
+import java.util.Optional;
+
+public interface MessageAndClaimsHandler<T extends Message> extends MessageHandler<T>{
+
+    @Override
+    default MessageResponse handleMessage(T queryHeader, MessagePayload payload) throws MessageHandlerException {
+        return handleMessage(queryHeader, payload, Optional.empty());
+    }
+
+    MessageResponse handleMessage(T queryHeader, MessagePayload payload, Optional<Jws<Claims>> optionalClaimsJws) throws MessageHandlerException;
+
+
+}

--- a/messaging/src/main/java/de/fraunhofer/ids/messaging/handler/message/MessageAndClaimsHandler.java
+++ b/messaging/src/main/java/de/fraunhofer/ids/messaging/handler/message/MessageAndClaimsHandler.java
@@ -1,3 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.fraunhofer.ids.messaging.handler.message;
 
 import de.fraunhofer.iais.eis.Message;

--- a/messaging/src/main/java/de/fraunhofer/ids/messaging/handler/message/MessageHandler.java
+++ b/messaging/src/main/java/de/fraunhofer/ids/messaging/handler/message/MessageHandler.java
@@ -15,6 +15,10 @@ package de.fraunhofer.ids.messaging.handler.message;
 
 import de.fraunhofer.iais.eis.Message;
 import de.fraunhofer.ids.messaging.response.MessageResponse;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+
+import java.util.Optional;
 
 public interface MessageHandler<T extends Message> {
 

--- a/messaging/src/main/java/de/fraunhofer/ids/messaging/handler/message/MessageHandler.java
+++ b/messaging/src/main/java/de/fraunhofer/ids/messaging/handler/message/MessageHandler.java
@@ -15,10 +15,6 @@ package de.fraunhofer.ids.messaging.handler.message;
 
 import de.fraunhofer.iais.eis.Message;
 import de.fraunhofer.ids.messaging.response.MessageResponse;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jws;
-
-import java.util.Optional;
 
 public interface MessageHandler<T extends Message> {
 

--- a/messaging/src/main/java/de/fraunhofer/ids/messaging/requests/exceptions/IdsRequestException.java
+++ b/messaging/src/main/java/de/fraunhofer/ids/messaging/requests/exceptions/IdsRequestException.java
@@ -17,7 +17,7 @@ public class IdsRequestException extends Exception {
 
     public IdsRequestException() { }
 
-    public IdsRequestException(final String message){
+    public IdsRequestException(final String message) {
         super(message);
     }
 }

--- a/messaging/src/test/java/de/fraunhofer/ids/messaging/dispatcher/testhandlers/NotificationMessageHandler.java
+++ b/messaging/src/test/java/de/fraunhofer/ids/messaging/dispatcher/testhandlers/NotificationMessageHandler.java
@@ -14,19 +14,20 @@
 package de.fraunhofer.ids.messaging.dispatcher.testhandlers;
 
 import de.fraunhofer.iais.eis.NotificationMessageImpl;
-import de.fraunhofer.ids.messaging.handler.message.MessageHandler;
-import de.fraunhofer.ids.messaging.handler.message.MessageHandlerException;
-import de.fraunhofer.ids.messaging.handler.message.MessagePayload;
-import de.fraunhofer.ids.messaging.handler.message.SupportedMessageType;
+import de.fraunhofer.ids.messaging.handler.message.*;
 import de.fraunhofer.ids.messaging.response.MessageResponse;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
 import lombok.NoArgsConstructor;
+
+import java.util.Optional;
 
 @NoArgsConstructor
 @SupportedMessageType(NotificationMessageImpl.class)
-public class NotificationMessageHandler implements MessageHandler<NotificationMessageImpl> {
+public class NotificationMessageHandler implements MessageAndClaimsHandler<NotificationMessageImpl> {
     @Override
     public MessageResponse handleMessage(final NotificationMessageImpl queryHeader,
-                                          final MessagePayload payload) throws MessageHandlerException {
+                                         final MessagePayload payload, final Optional<Jws<Claims>> claimsJws) throws MessageHandlerException {
         throw new MessageHandlerException("Failed to handle message!");
     }
 }

--- a/messaging/src/test/java/de/fraunhofer/ids/messaging/dispatcher/testhandlers/RequestMessageHandler.java
+++ b/messaging/src/test/java/de/fraunhofer/ids/messaging/dispatcher/testhandlers/RequestMessageHandler.java
@@ -14,6 +14,7 @@
 package de.fraunhofer.ids.messaging.dispatcher.testhandlers;
 
 import java.net.URI;
+import java.util.Optional;
 
 import de.fraunhofer.iais.eis.RejectionReason;
 import de.fraunhofer.iais.eis.RequestMessageImpl;
@@ -23,6 +24,8 @@ import de.fraunhofer.ids.messaging.handler.message.MessagePayload;
 import de.fraunhofer.ids.messaging.handler.message.SupportedMessageType;
 import de.fraunhofer.ids.messaging.response.ErrorResponse;
 import de.fraunhofer.ids.messaging.response.MessageResponse;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
@@ -30,7 +33,7 @@ import lombok.NoArgsConstructor;
 public class RequestMessageHandler implements MessageHandler<RequestMessageImpl> {
     @Override
     public MessageResponse handleMessage( final RequestMessageImpl queryHeader,
-                                          final MessagePayload payload) throws MessageHandlerException {
+                                          final MessagePayload payload) {
         return ErrorResponse.withDefaultHeader(RejectionReason.BAD_PARAMETERS,
                                                "request",
                                                URI.create("http://uri"),

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     </modules>
 
     <properties>
-        <revision>4.2.0.0</revision>
+        <revision>2.0.0-SNAPSHOT</revision>
 
         <java.version>11</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>


### PR DESCRIPTION
Add a new MessageHandler, which can pass the parsed DAT Claims to the Connector, which can then be used for additional checks.