### PR TITLE
feat: validity check for proxy hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 
 ### Patch Change: Fixes
 - For incoming responses to sent requests, an IOException is now no longer thrown for response codes outside 200-299. These responses may also be valid IDS-messages, for example a RejectionMessage with the status BAD_REQUEST. ([Issue 277](https://github.com/International-Data-Spaces-Association/IDS-Messaging-Services/issues/277))
+- If the connector's proxy configuration contains an incorrect empty hostname, a warning message is now logged and an attempt is made to send the message without this proxy instead of throwing an IllegalArgumentException. ([Issue 285](https://github.com/International-Data-Spaces-Association/IDS-Messaging-Services/pull/285))
 
 ### Patch Change: Dependency Maintenance
 - Upgrade: com.puppycrawl.tools:checkstyle 8.45.1 -> 9.0 ([PR 275](https://github.com/International-Data-Spaces-Association/IDS-Messaging-Services/pull/275))

--- a/core/src/main/java/de/fraunhofer/ids/messaging/core/config/ClientProvider.java
+++ b/core/src/main/java/de/fraunhofer/ids/messaging/core/config/ClientProvider.java
@@ -186,6 +186,13 @@ public class ClientProvider {
                             log.warn("Proxy hostname invalid! Trying to skip using this proxy!"
                                      + " Please check configuration! [hostname=({})]", proxyHost);
                         }
+                        proxyList.add(Proxy.NO_PROXY);
+                    } else if (proxyPort == -1) {
+                        if (log.isWarnEnabled()) {
+                            log.warn("Proxy port invalid! Trying to skip using this proxy!"
+                                    + " Please check configuration! [port=({})]", proxyPort);
+                        }
+                        proxyList.add(Proxy.NO_PROXY);
                     } else {
                         proxyList.add(new Proxy(Proxy.Type.HTTP,
                                             new InetSocketAddress(proxyHost, proxyPort)));

--- a/core/src/main/java/de/fraunhofer/ids/messaging/core/config/ClientProvider.java
+++ b/core/src/main/java/de/fraunhofer/ids/messaging/core/config/ClientProvider.java
@@ -180,8 +180,17 @@ public class ClientProvider {
                     if (log.isDebugEnabled()) {
                         log.debug("Address: [host=({})], Port: [port=({})]", proxyHost, proxyPort);
                     }
-                    proxyList.add(new Proxy(Proxy.Type.HTTP,
-                        new InetSocketAddress(proxyHost, proxyPort)));
+
+                    if (proxyHost == null || proxyHost.trim().equals("")) {
+                        if (log.isWarnEnabled()) {
+                            log.warn("Proxy hostname invalid! Trying to skip using this proxy!"
+                                     + " Please check configuration! [hostname=({})]", proxyHost);
+                        }
+                    } else {
+                        proxyList.add(new Proxy(Proxy.Type.HTTP,
+                                            new InetSocketAddress(proxyHost, proxyPort)));
+                    }
+
                 }
                 return proxyList;
             }

--- a/core/src/test/java/de/fraunhofer/ids/messaging/core/config/ConfigProducerTest.java
+++ b/core/src/test/java/de/fraunhofer/ids/messaging/core/config/ConfigProducerTest.java
@@ -75,7 +75,7 @@ class ConfigProducerTest {
         final var tokenManagerService = new AisecTokenManagerService(clientProvider, configContainer);
         assertEquals("INVALID_TOKEN", tokenManagerService.acquireToken("https://daps.aisec.fraunhofer.de/v2/token"));
 
-        //orbiter DAPS currently not reachable (and currently not added to test connectors NO_PROXY), so this should throw an IllegalArgumentException
+        //orbiter DAPS currently not functional reachable
         //test will either throw IllegalArgumentException (URL not reachable) or JSONException (some HTML error code returned)
         //test will fail, if Orbiter DAPS reachable and working again
         final var orbiterTokenManagerService = new OrbiterTokenManagerService(clientProvider);

--- a/core/src/test/java/de/fraunhofer/ids/messaging/core/config/ConfigProducerTest.java
+++ b/core/src/test/java/de/fraunhofer/ids/messaging/core/config/ConfigProducerTest.java
@@ -76,7 +76,9 @@ class ConfigProducerTest {
         assertEquals("INVALID_TOKEN", tokenManagerService.acquireToken("https://daps.aisec.fraunhofer.de/v2/token"));
 
         //orbiter DAPS currently not reachable (and currently not added to test connectors NO_PROXY), so this should throw an IllegalArgumentException
+        //test will either throw IllegalArgumentException (URL not reachable) or JSONException (some HTML error code returned)
+        //test will fail, if Orbiter DAPS reachable and working again
         final var orbiterTokenManagerService = new OrbiterTokenManagerService(clientProvider);
-        assertThrows(IllegalArgumentException.class, () -> orbiterTokenManagerService.acquireToken("https://orbiter-daps-staging.truzzt.org/api/oauth/token"));
+        assertThrows(Exception.class, () -> orbiterTokenManagerService.acquireToken("https://orbiter-daps-staging.truzzt.org/api/oauth/token"));
     }
 }


### PR DESCRIPTION
Invalid proxy-hostname will now issue following warn-log and try to send message without proxy:

```
2021-09-09T15:54:21,668 [https-jsse-nio-8080-exec-9] WARN - Proxy hostname invalid! Trying to skip using this proxy! Please check configuration! [hostname=(null)]
2021-09-09T15:54:22,290 [https-jsse-nio-8080-exec-9] INFO - Successfully received DAT from DAPS.
2021-09-09T15:54:22,561 [https-jsse-nio-8080-exec-9] INFO - Sending request to https://binac.fit.fraunhofer.de/api/ids/data ...
```