### PR TITLE
feat: check if keystore-location is null on init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 - Upgrade: org.apache.maven.plugins:maven-javadoc-plugin 3.3.0 -> 3.3.1 ([PR 281](https://github.com/International-Data-Spaces-Association/IDS-Messaging-Services/pull/281))
 
 ### Patch Change: Miscellaneous
+- Due to an incorrect or missing connector configuration it could happen that the location of the KeyStore is null. This is now handled in the form of a KeyStoreManagerInitializationException and log message at KeyStoreManager init. ([Issue 290](https://github.com/International-Data-Spaces-Association/IDS-Messaging-Services/issues/290))
 - Other minor enhancements to existing Javadoc.
 
 ## Version [4.3.0] 2021-08-31

--- a/core/src/main/java/de/fraunhofer/ids/messaging/core/config/ssl/keystore/KeyStoreManager.java
+++ b/core/src/main/java/de/fraunhofer/ids/messaging/core/config/ssl/keystore/KeyStoreManager.java
@@ -325,6 +325,7 @@ public class KeyStoreManager {
 
     /**
      * Checks whether the keystore path specification is set in the connector configuration.
+     *
      * @param location The keystore path.
      * @param keyStoreType Indication whether it is keystore or truststore.
      * @throws KeyStoreManagerInitializationException Thrown if location specification is not set.

--- a/core/src/main/java/de/fraunhofer/ids/messaging/core/config/ssl/keystore/KeyStoreManager.java
+++ b/core/src/main/java/de/fraunhofer/ids/messaging/core/config/ssl/keystore/KeyStoreManager.java
@@ -240,6 +240,9 @@ public class KeyStoreManager {
             NoSuchAlgorithmException,
             IOException,
             KeyStoreManagerInitializationException {
+
+        validateLocation(location, keyStoreType);
+
         if (log.isDebugEnabled()) {
             log.debug("Searching for keystore file. [location=({})]", location.toString());
         }
@@ -318,6 +321,25 @@ public class KeyStoreManager {
             log.info("Successfully loaded {}.", keyStoreType);
         }
         return store;
+    }
+
+    /**
+     * Checks whether the keystore path specification is set in the connector configuration.
+     * @param location The keystore path.
+     * @param keyStoreType Indication whether it is keystore or truststore.
+     * @throws KeyStoreManagerInitializationException Thrown if location specification is not set.
+     */
+    private void validateLocation(final URI location, final String keyStoreType)
+            throws KeyStoreManagerInitializationException {
+        if (location == null) {
+            if (log.isErrorEnabled()) {
+                log.error("Location input for keystore-path from connector configuration"
+                          + " is not valid!"
+                         + " [type=({}), location=(null)]", keyStoreType);
+            }
+            throw new KeyStoreManagerInitializationException(
+                    "Location input for keystore-path is null! Type: " + keyStoreType);
+        }
     }
 
     @Nullable

--- a/core/src/main/java/de/fraunhofer/ids/messaging/core/config/ssl/keystore/KeyStoreManagerInitializationException.java
+++ b/core/src/main/java/de/fraunhofer/ids/messaging/core/config/ssl/keystore/KeyStoreManagerInitializationException.java
@@ -28,4 +28,13 @@ public class KeyStoreManagerInitializationException extends Exception {
     public KeyStoreManagerInitializationException(final String message, final Throwable cause) {
         super(message, cause);
     }
+
+    /**
+     * Create a KeyStoreManagerInitializationException with a given Message.
+     *
+     * @param message Error message of the exception.
+     */
+    public KeyStoreManagerInitializationException(final String message) {
+        super(message);
+    }
 }


### PR DESCRIPTION
Due to an incorrect or missing connector configuration it could happen that the location of the KeyStore is null. This is now handled in the form of a KeyStoreManagerInitializationException and log message at KeyStoreManager init.