### PR TITLE
feat: log incoming and outgoing messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,8 @@ The new repository can be included in projects as follows. As of version 7.0.0, 
 ### Minor Change: Logging of incoming and outgoing messages
 It is as of now possible to log incoming messages (header, not payload), send requests and received responses to send requests. Following new optional application.properties settings are provided to enable or disable logging:
 
-- `messaging.log.incoming=true/false` Logs all header of incoming messages at info level. Default if not set is false = turned off.
-- `messaging.log.requests=true/false` Logs all send requests at info level. Default if not set is false = turned off.
-- `messaging.log.responses=true/false` Logs all responses to send requests at info level. Default if not set is false = turned off.
+- `messaging.log.incoming=true/false` Logs all incoming messages at info level (incoming requests + incoming responses to self-send requests). Default if not set is false = turned off.
+- `messaging.log.outgoing=true/false` Logs all outgoing messages at info level (outgoing requests + outgoing responses to incoming requests). Default if not set is false = turned off.
 
 ### Patch Change: Fixes
 - ReferingConnector validation ([PR 526](https://github.com/International-Data-Spaces-Association/IDS-Messaging-Services/pull/526))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 
 ## Version [7.0.0] SNAPSHOT
 
-### Organizational Note:
+### Organizational Note (major change):
 The IDSA repository of the IDS-Messaging-Services is maintained by `sovity GmbH` as of this release. This changes the naming of the internal package structure and, most importantly, the repository in which the artifacts are published.
 
 The new repository can be included in projects as follows. As of version 7.0.0, the releases are published here:
@@ -21,7 +21,14 @@ The new repository can be included in projects as follows. As of version 7.0.0, 
         <url>https://pkgs.dev.azure.com/sovity/5bec6cbd-c80a-47ac-86ce-1deb26cee853/_packaging/artifact/maven/v1</url>
     </repository>
 
-### Fixes
+### Minor Change: Logging of incoming and outgoing messages
+It is as of now possible to log incoming messages (header, not payload), send requests and received responses to send requests. Following new optional application.properties settings are provided to enable or disable logging:
+
+- `messaging.log.incoming=true/false` Logs all header of incoming messages at info level. Default if not set is false = turned off.
+- `messaging.log.requests=true/false` Logs all send requests at info level. Default if not set is false = turned off.
+- `messaging.log.responses=true/false` Logs all responses to send requests at info level. Default if not set is false = turned off.
+
+### Patch Change: Fixes
 - ReferingConnector validation ([PR 526](https://github.com/International-Data-Spaces-Association/IDS-Messaging-Services/pull/526))
 
 ### Patch Change: Other 

--- a/messaging/src/main/java/ids/messaging/endpoint/MessageController.java
+++ b/messaging/src/main/java/ids/messaging/endpoint/MessageController.java
@@ -21,6 +21,7 @@ package ids.messaging.endpoint;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -43,6 +44,7 @@ import ids.messaging.dispatcher.filter.PreDispatchingFilterException;
 import ids.messaging.protocol.multipart.parser.MultipartDatapart;
 import ids.messaging.util.IdsMessageUtils;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
@@ -79,6 +81,12 @@ public class MessageController {
      */
     @Value("#{new Boolean('${infomodel.compatibility.validation:true}')}")
     private Boolean validateInfVer;
+
+    /**
+     * Used to switch logging incoming requests off or on (default off).
+     */
+    @Value("#{new Boolean('${messaging.log.incoming:false}')}")
+    private Boolean logIncoming;
 
     /**
      * Constructor for the MessageController.
@@ -126,13 +134,23 @@ public class MessageController {
                                              "Header was missing!"));
             }
 
+            final var headerBytes = IOUtils.toByteArray(headerPart.getInputStream());
+            if (Boolean.TRUE.equals(logIncoming)) {
+                final var headerInput = new ByteArrayInputStream(headerBytes);
+                log.info("Incoming message header: {}",
+                        IOUtils.toString(headerInput, StandardCharsets.UTF_8));
+                headerInput.close();
+            }
+
             String input;
 
             if (log.isDebugEnabled()) {
                 log.debug("Parsing header of incoming message. [code=(IMSMED0120)]");
             }
 
-            try (var scanner = new Scanner(headerPart.getInputStream(),
+            final var headerInput = new ByteArrayInputStream(headerBytes);
+
+            try (var scanner = new Scanner(headerInput,
                                            StandardCharsets.UTF_8.name())) {
                 input = scanner.useDelimiter("\\A").next();
             }

--- a/messaging/src/main/java/ids/messaging/endpoint/MessageController.java
+++ b/messaging/src/main/java/ids/messaging/endpoint/MessageController.java
@@ -89,6 +89,12 @@ public class MessageController {
     private Boolean logIncoming;
 
     /**
+     * Used to switch logging send responses to incoming requests off or on (default off).
+     */
+    @Value("#{new Boolean('${messaging.log.outgoing:false}')}")
+    private Boolean logResponse;
+
+    /**
      * Constructor for the MessageController.
      * @param messageDispatcher The MessageDispatcher.
      * @param serializer The infomodel serializer.
@@ -200,6 +206,8 @@ public class MessageController {
                     log.info("Sending response with status OK (200).");
                 }
 
+                logSendResponse(responseAsMap);
+
                 return ResponseEntity
                         .status(HttpStatus.OK)
                         .contentType(MediaType.MULTIPART_FORM_DATA)
@@ -256,6 +264,13 @@ public class MessageController {
                              RejectionReason.INTERNAL_RECIPIENT_ERROR,
                              String.format(
                                  "Could not read incoming request! Error: %s", e.getMessage())));
+        }
+    }
+
+    private void logSendResponse(final MultiValueMap<String, Object> responseAsMap) {
+        if (Boolean.TRUE.equals(logResponse)) {
+            final var header = responseAsMap.get(MultipartDatapart.HEADER.toString()).toString();
+            log.info("Send response header: {}", header);
         }
     }
 

--- a/messaging/src/main/java/ids/messaging/endpoint/MessageController.java
+++ b/messaging/src/main/java/ids/messaging/endpoint/MessageController.java
@@ -161,6 +161,8 @@ public class MessageController {
                 input = scanner.useDelimiter("\\A").next();
             }
 
+            headerInput.close();
+
             final var infomodelCompability = validateInfomodelVersion(input);
 
             if (infomodelCompability.isPresent()) {
@@ -206,7 +208,7 @@ public class MessageController {
                     log.info("Sending response with status OK (200).");
                 }
 
-                logSendResponse(responseAsMap);
+                logResponseHeader(responseAsMap);
 
                 return ResponseEntity
                         .status(HttpStatus.OK)
@@ -267,7 +269,7 @@ public class MessageController {
         }
     }
 
-    private void logSendResponse(final MultiValueMap<String, Object> responseAsMap) {
+    private void logResponseHeader(final MultiValueMap<String, Object> responseAsMap) {
         if (Boolean.TRUE.equals(logResponse)) {
             final var header = responseAsMap.get(MultipartDatapart.HEADER.toString()).toString();
             log.info("Send response header: {}", header);

--- a/messaging/src/main/java/ids/messaging/protocol/http/IdsHttpService.java
+++ b/messaging/src/main/java/ids/messaging/protocol/http/IdsHttpService.java
@@ -99,13 +99,13 @@ public class IdsHttpService implements HttpService {
     /**
      * Used to switch logging incoming responses off or on (default off).
      */
-    @Value("#{new Boolean('${messaging.log.responses:false}')}")
+    @Value("#{new Boolean('${messaging.log.incoming:false}')}")
     private Boolean logResponses;
 
     /**
      * Used to switch logging sending requests off or on (default off).
      */
-    @Value("#{new Boolean('${messaging.log.requests:false}')}")
+    @Value("#{new Boolean('${messaging.log.outgoing:false}')}")
     private Boolean logRequests;
 
     /**


### PR DESCRIPTION
includes 2 new application properties settings, to enable or disable logging of incoming and outgoing messages. Default is disabled (false)
```
messaging.log.incoming=true/false (incoming requests + incoming responses to self-send requests)
messaging.log.outgoing=true/false (outgoing requests + outgoing responses to incoming requests)
```