### PR TITLE
Update IAIS Maven Repository URL (http:// -> https://)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
                 <enabled>false</enabled>
             </snapshots>
             <id>eis-public-repo</id>
-            <url>http://maven.iais.fraunhofer.de/artifactory/eis-ids-public</url>
+            <url>https://maven.iais.fraunhofer.de/artifactory/eis-ids-public</url>
         </repository>
         <repository>
             <id>sovity-public</id>


### PR DESCRIPTION
http://maven.iais.fraunhofer.de/ui/native/eis-ids-public isn't accessible anymore, but 
https://maven.iais.fraunhofer.de/ui/native/eis-ids-public is accessible


related: https://github.com/International-Data-Spaces-Association/DataspaceConnector/issues/678